### PR TITLE
docs: enhance README with project background and archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# TodoApp
+# Todo App
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 13.2.4.
+> **Note:** This repository is archived and no longer maintained.
+
+This project is an Angular solution to the [Todo App challenge on Frontend Mentor](https://www.frontendmentor.io/challenges/todo-app-Su1_KokOW). I built it when I first started learning Angular, after finishing a few smaller vanilla JavaScript projects.
+
+The application lets you create, complete, filter and remove todo items and persists them in the browser. It was a fun way to explore components, two-way data binding and the Angular CLI.
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
-
-## Code scaffolding
-
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+1. Install dependencies with `npm install`.
+2. Run `ng serve` for a development server and navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 
 ## Build
 
@@ -16,11 +17,7 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 
 ## Running unit tests
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+Run `npm test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
 ## Further help
 


### PR DESCRIPTION
## Summary
- describe this Angular todo app as an early project tackling the Frontend Mentor challenge
- add basic setup and test instructions in the README
- note the repository is archived and no longer maintained

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y chromium` *(fails: Unable to locate package chromium)*
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b01f730c83218e1d37150d027540